### PR TITLE
American Trade 2.0.1 Manilla (#107)

### DIFF
--- a/localisation/tradenodes_l_english.yml
+++ b/localisation/tradenodes_l_english.yml
@@ -230,7 +230,7 @@
  pacific_islands:0 "Pacific Islands"
  kr_hsh:0 "Korea-Honshu"
  smanchuria:0 "Southern Manchuria"
- e_pacific:0 "East Pacific"
- w_pacific:0 "West Pacific"
+ e_pacific:0 "American North Pacific"
+ w_pacific:0 "Northern Asia"
  luzviminda:0 "Luzviminda"
  

--- a/localisation/tradenodes_l_french.yml
+++ b/localisation/tradenodes_l_french.yml
@@ -230,6 +230,9 @@
  pacific_islands:0 "Îles du Pacifique"
  kr_hsh:0 "Corée-Honshu"
  smanchuria:0 "Mandchourie du Sud"
- e_pacific:0 "Pacifique Est"
- w_pacific:0 "Pacifique Ouest"
+ e_pacific:0 "Nord Pacifique Américain"
+ w_pacific:0 "Asie du Nord"
  luzviminda:0 "Luzviminda"
+
+ 
+ 

--- a/localisation/tradenodes_l_german.yml
+++ b/localisation/tradenodes_l_german.yml
@@ -230,6 +230,6 @@
  pacific_islands:0 "Pazifische Inseln"
  kr_hsh:0 "Korea-Honshu"
  smanchuria:0 "Südmandschurei"
- e_pacific:0 "Ostpazifik"
- w_pacific:0 "Westpazifik"
+ e_pacific:0 "Amerikanischer Nordpazifik"
+ w_pacific:0 "Nordazien"
  luzviminda:0 "Luzviminda"

--- a/localisation/tradenodes_l_spanish.yml
+++ b/localisation/tradenodes_l_spanish.yml
@@ -230,6 +230,6 @@
  pacific_islands:0 "Islas del Pacífico"
  kr_hsh:0 "Corea-Honshu"
  smanchuria:0 "Manchuria del Sur"
- e_pacific:0 "Pacífico Este"
- w_pacific:0 "Pacífico Oeste"
+ e_pacific:0 "Pacífico Norte Americano"
+ w_pacific:0 "Norte de Asia"
  luzviminda:0 "Luzviminda"


### PR DESCRIPTION
* Localization e_pacific + w_pacific

e_pacific to American North Pacific
w_pacific to Northern Asia

* Fr Localization e_pacific + w_pacific 

e_pacific to Nord Pacifique Américain
w_pacific to Asie du Nord

* Ger Localization e_pacific + w_pacific

* Update tradenodes_l_spanish.yml